### PR TITLE
Add ignore specific plugins command feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ myClient.on('!join', function (command) {
 });
 
 // Load a plugin.
-myClient.initialize(require('./yourPlugin'));
+myClient.initializePlugin(require('./yourPlugin'));
 
 // Or just use a plugin from tennu_plugins/%f or node_plugins/tennu-%f
 myClient.use(['admin', 'last-seen']);

--- a/src/lib/client.sjs
+++ b/src/lib/client.sjs
@@ -70,14 +70,14 @@ const loggerMethods = ["debug", "info", "notice", "warn", "error", "crit", "aler
     client._config = config = defaults({}, config, defaultClientConfiguration);
     // TODO(Havvy): Handle the logic in here better. Maybe move config validation to seperate module?
 
-    if(config['ignore-command-list'])
+    if(config['command-ignore-list'])
     {
-        var arrayItems = config['ignore-command-list'].filter(function (item) {
+        var arrayItems = config['command-ignore-list'].filter(function (item) {
             return Array.isArray(item);
         }).filter(function (arrayItem) {
             return arrayItem.length < 2;
         });
-        if(element.length < 2)
+        if(arrayItems.length > 0)
         {
             throw new Error("Invalid command-ignore-list configuration option value. Arrays in command-ignore-list must have more than 1 object.");
         }        

--- a/src/lib/client.sjs
+++ b/src/lib/client.sjs
@@ -68,7 +68,20 @@ const loggerMethods = ["debug", "info", "notice", "warn", "error", "crit", "aler
 
     // Parse the configuration object. Make it immutable.
     client._config = config = defaults({}, config, defaultClientConfiguration);
-    // TODO(Havvy): Handle the logic in here better.
+    // TODO(Havvy): Handle the logic in here better. Maybe move config validation to seperate module?
+
+    if(config['ignore-command-list'])
+    {
+        var arrayItems = config['ignore-command-list'].filter(function (item) {
+            return Array.isArray(item);
+        }).filter(function (arrayItem) {
+            return arrayItem.length < 2;
+        });
+        if(element.length < 2)
+        {
+            throw new Error("Invalid command-ignore-list configuration option value. Arrays in command-ignore-list must have more than 1 object.");
+        }        
+    }
 
     if (config.daemon === "twitch") {
         // Twitch.tv doesn't allow capabilities.

--- a/src/plugin/commands.sjs
+++ b/src/plugin/commands.sjs
@@ -123,25 +123,16 @@ module.exports = {
                             return;
                         }
                         
-                        for(var i = 0; i < ignoreCommandInSpecificPluginList.length; i++)
-                        {
-                            var specificIgnore = ignoreCommandInSpecificPluginList[i];
-                            if(specificIgnore.length < 2)
-                            {
-                                var errorMessage = format("Invalid ignore-command-list configuration option value.");
-                                client.error("PluginCommands", errorMessage);
-                                throw new Error(errorMessage);                                
-                            }
-                            
-                            if(specificIgnore[0] === commandName && specificIgnore.slice(1, specificIgnore.length).indexOf(plugin) !== -1)
+                        ignoreCommandInSpecificPluginList.some(function (element, index, array) {
+                            if(element[0] === commandName && element.slice(1, element.length).indexOf(plugin) !== -1)
                             {
                                 client.note("PluginCommands", format("Ignoring '%s:%s'.", plugin, commandName));
                                 return;
                             }
-                        }
+                        });
                                             
                         if (commandName in registry) {
-                            var errorMessage = format("Command '%s' already has a handler from plugin '%s'.", commandName, registry[commandName].plugin);
+                            const errorMessage = format("Command '%s' already has a handler from plugin '%s'.", commandName, registry[commandName].plugin);
                             client.error("PluginCommands", errorMessage);
                             throw new Error(errorMessage);
                         }

--- a/src/plugin/commands.sjs
+++ b/src/plugin/commands.sjs
@@ -123,13 +123,17 @@ module.exports = {
                             return;
                         }
                         
-                        ignoreCommandInSpecificPluginList.some(function (element, index, array) {
+                        var ignoreMatchFound = ignoreCommandInSpecificPluginList.some(function (element, index, array) {
                             if(element[0] === commandName && element.slice(1, element.length).indexOf(plugin) !== -1)
                             {
                                 client.note("PluginCommands", format("Ignoring '%s:%s'.", plugin, commandName));
-                                return;
+                                return true;
                             }
                         });
+                        if(ignoreMatchFound)
+                        {
+                            return;
+                        }
                                             
                         if (commandName in registry) {
                             const errorMessage = format("Command '%s' already has a handler from plugin '%s'.", commandName, registry[commandName].plugin);


### PR DESCRIPTION
]https://github.com/Tennu/tennu/issues/60#issuecomment-155360581

I have added the ability to pass an array to command-ignore-list, the array must have > 1 strings in it.

The first string is the command, and all subsequent strings are plugins that will have their attempts to register the command with tennu ignored.

**To disable tennu-control say for example:**
```javascript
"command-ignore-list": [ [ "say", "control" ] ]
```