### PR TITLE
examples/config.json: remove trailing comma

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -12,5 +12,5 @@
     "nickserv": "nickserv",
     "auth-password": null,
 
-    "tls": false,
+    "tls": false
 }


### PR DESCRIPTION
JSON.parse can't deal with the trailing comma.