### PR TITLE
Add response function to the action plugin, expose to client

### DIFF
--- a/src/lib/client.sjs
+++ b/src/lib/client.sjs
@@ -231,6 +231,7 @@ Client.prototype.notice                 = delegate_ret _action notice;
 Client.prototype.part                   = delegate_ret _action part;
 Client.prototype.quit                   = delegate_ret _action quit;
 Client.prototype.say                    = delegate_ret _action say;
+Client.prototype.respond                = delegate_ret _action respond;
 Client.prototype.userhost               = delegate_ret _action userhost;
 Client.prototype.who                    = delegate_ret _action who;
 Client.prototype.whois                  = delegate_ret _action whois;

--- a/src/plugin/action/index.sjs
+++ b/src/plugin/action/index.sjs
@@ -3,10 +3,16 @@ const format = require("util").format;
 const chunk = require("chunk");
 const Promise = require("bluebird");
 const EventEmitter = require("events").EventEmitter;
+const Response = require("../../lib/response");
 
 module.exports = ActionPlugin = {
     init: function (client, imports) {
         const emitter = new EventEmitter();
+
+        function respond (handlerResponse, message) {
+            var response = Response.create(handlerResponse, message);
+            Response.send(response, client);
+        }
 
         function raw (line) {
             if (Array.isArray(line)) { line = line.join(" "); }
@@ -136,6 +142,8 @@ module.exports = ActionPlugin = {
         return {
             exports: {
                 emitter: emitter,
+
+                respond: respond,
 
                 raw: raw,
                 rawf: rawf,


### PR DESCRIPTION
Added a function called 'response' which lets you send a response directly to the actions plugin for execution.

## Usage:
```Javascript
function (command) {
    client.response({
        intent: 'notice',
        query: true,
        message: ['Hello', 'World']
    }, command);
}
```

### Why?
This is useful for plugins that have response factories which might churn out responses in an array. In my case, I have a database driven plugin which compiles a list of various responses and is essentially re-writing the response.js module to fire act/notice/say/raw when it needs it.

### Alternatives?
I suppose if response.js create() function could take an array, that might be a good alternative.