### PR TITLE
Support for new twitch capabilities

### DIFF
--- a/src/plugin/config.sjs
+++ b/src/plugin/config.sjs
@@ -7,14 +7,13 @@ module.exports = {
     init: function (client, deps) {
         const config = client._configObject;
 
-        if (config.daemon === "twitch" || config.daemon === "irc2") {
+        if (config.daemon === "irc2") {
             if (config.capabilities && config.capabilities.requires && config.capabilities.requires.length > 0) {
                 throw new Error("IRCd doesn't support capabilities. Cannot require them. Fix your configuration.");
             }
-            // Twitch.tv doesn't allow capabilities.
             // GameSurge doesn't support capabilities.
             config.capabilities = undefined;
-        } else {
+        } else if (config.daemon !== "twitch") {
             if (!config.capabilities) {
                 config.capabilities = { requires: ["multi-prefix"] };
             } else if (!config.capabilities.requires) {


### PR DESCRIPTION
Fix for #76 

Twitch now support capabilities, and have three available (https://dev.twitch.tv/docs/irc#twitch-capabilities) but they don't support multi-prefix (not does the channel plugin work)

This PR allows capability setting when daemon is set to twitch and doesn't require multi-prefix